### PR TITLE
fix(deps): Ensure kotlin is available at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Go inside `nodes/` and run
 ```
 Built `nodes-VERSION.jar` will appear in `build/libs/`.
 
-Nodes also requires a seperate kotlin runtime plugin, for example my <https://github.com/d-z4/minecraft-kotlin>),
-
 -----------------------------------------------------------
 
 ## 2. Building dynmap viewer/editor

--- a/nodes/src/main/resources/plugin.yml
+++ b/nodes/src/main/resources/plugin.yml
@@ -4,6 +4,8 @@ version: 0.0.14
 api-version: 1.16
 folia-supported: true
 softdepend: [kotlin, Essentials]
+libraries:
+  - org.jetbrains.kotlin:kotlin-stdlib:2.2.21
 commands:
   nodesadmin:
     description: Admin commands for Nodes

--- a/nodes/src/main/resources/plugin.yml
+++ b/nodes/src/main/resources/plugin.yml
@@ -2,9 +2,10 @@ main: phonon.nodes.NodesPlugin
 name: nodes
 version: 0.0.14
 api-version: 1.16
-softdepend: [kotlin, Essentials]
+
 libraries:
   - org.jetbrains.kotlin:kotlin-stdlib:2.2.21
+
 commands:
   nodesadmin:
     description: Admin commands for Nodes


### PR DESCRIPTION
Opted to use server-side Kotlin rather than shading it into the plugin.
This avoids duplicate dependencies when multiple plugins use Kotlin.

I also removed the softdepend on Essentials because 1) Essentials is not used as far as I can see inside the plugin, and 2) Essentials so full of bugs it makes it way too easy to dupe things if you even slightly misconfigure something.